### PR TITLE
Match Exact Headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "standard", "~> 1.3"
+
+gem "rspec", "~> 3.0"
+gem "rack"
+gem "cgi"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
     diff-lcs (1.6.1)
     json (2.7.2)
     language_server-protocol (3.17.0.4)
@@ -45,7 +46,16 @@ GEM
     rake (13.2.1)
     regexp_parser (2.9.2)
     rexml (3.3.9)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
@@ -87,8 +97,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  cgi
   match_table!
+  rack
   rake (~> 13.0)
+  rspec (~> 3.0)
   standard (~> 1.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,11 +27,11 @@ GEM
     lint_roller (1.1.0)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
-    nokogiri (1.18.7)
+    mini_portile2 (2.8.9)
+    nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.7-arm64-darwin)
+    nokogiri (1.19.0-arm64-darwin)
       racc (~> 1.4)
     parallel (1.25.1)
     parser (3.3.3.0)
@@ -105,4 +105,4 @@ DEPENDENCIES
   standard (~> 1.3)
 
 BUNDLED WITH
-   2.6.3
+  4.0.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 require "standard/rake"
 
-task default: :standard
+RSpec::Core::RakeTask.new(:spec)
+
+task default: [:spec, :standard]

--- a/lib/match_table.rb
+++ b/lib/match_table.rb
@@ -32,7 +32,7 @@ RSpec::Matchers.define :match_table do |table|
 
         header_positions =
           expected_headers.each_with_object({}) do |header, hash|
-            position = @actual_headers.find_index { |actual_header| actual_header.start_with?(header) }
+            position = @actual_headers.find_index { |actual_header| actual_header == header }
             unless position.nil?
               hash[header] = position
             end
@@ -113,7 +113,7 @@ RSpec::Matchers.define :match_table do |table|
     @actual_headers =
       table.find("thead").all("th", visible: :all).map do |element|
         text = element.text
-        if text.blank?
+        if text.nil? || text.empty?
           text = element.first("[data-role]", visible: :all, minimum: 0)&.text(:all) || ""
         end
 

--- a/lib/match_table.rb
+++ b/lib/match_table.rb
@@ -117,7 +117,7 @@ RSpec::Matchers.define :match_table do |table|
           text = element.first("[data-role]", visible: :all, minimum: 0)&.text(:all) || ""
         end
 
-        text
+        normalize_header_text(text)
       end
 
     @actual_rows = []
@@ -125,9 +125,12 @@ RSpec::Matchers.define :match_table do |table|
     tbody = table.find("tbody:not(.contents)")
     rows = tbody.all("tr[data-table-target='row']")
 
-    # Filter out rows that are inside accordion content tables
+    # Filter out rows that are inside accordion content of table rows
+    # Only reject rows that are inside a tr[data-accordion-content] that is within this specific table
     rows = rows.reject do |row|
-      row.matches_css?("[data-accordion-content] table tr")
+      row.ancestor("tr[data-accordion-content]", minimum: 0)
+    rescue Capybara::ElementNotFound
+      false
     end
 
     rows.each do |row|
@@ -140,6 +143,15 @@ RSpec::Matchers.define :match_table do |table|
     header_positions.each_with_object({}) do |(header, position), matched_row|
       matched_row[header] = actual_row[position]
     end
+  end
+
+  def normalize_header_text(text)
+    return text if text.nil? || text.empty?
+
+    text
+      .gsub(/arrow_drop_(up|down)/, "")
+      .gsub(/\s+/, " ")
+      .strip
   end
 
   def append_to_failures_array_notifier

--- a/lib/match_table.rb
+++ b/lib/match_table.rb
@@ -122,8 +122,13 @@ RSpec::Matchers.define :match_table do |table|
 
     @actual_rows = []
 
-    rows = table.find("tbody:not(.contents)").all("tr[data-table-target='row']:not([data-accordion-content] table tr)").presence ||
-      table.find("tbody:not(.contents)").all("tr[data-table-target='row']")
+    tbody = table.find("tbody:not(.contents)")
+    rows = tbody.all("tr[data-table-target='row']")
+
+    # Filter out rows that are inside accordion content tables
+    rows = rows.reject do |row|
+      row.matches_css?("[data-accordion-content] table tr")
+    end
 
     rows.each do |row|
       cells = row.all("td")

--- a/spec/match_table_spec.rb
+++ b/spec/match_table_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "match_table"
+
+RSpec.describe "match_table matcher" do
+  include Capybara::DSL
+
+  before do
+    Capybara.app = -> (env) {
+      [200, {"Content-Type" => "text/html"}, [html]]
+    }
+    visit "/"
+  end
+
+  context "with exact header matching" do
+    let(:html) do
+      <<-HTML
+        <table id="users">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>John Doe</td>
+              <td>john@example.com</td>
+              <td>Active</td>
+            </tr>
+            <tr data-table-target="row">
+              <td>Jane Smith</td>
+              <td>jane@example.com</td>
+              <td>Inactive</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "matches when header case matches exactly" do
+      expect(page).to match_table(:users).with_rows(
+        {
+          "Name" => "John Doe",
+          "Email" => "john@example.com",
+          "Status" => "Active"
+        }
+      )
+    end
+
+    it "fails when header case does not match exactly" do
+      expect(page).not_to match_table(:users).with_rows(
+        {
+          "name" => "John Doe",
+          "email" => "john@example.com",
+          "status" => "Active"
+        }
+      )
+    end
+
+    it "fails when header has different capitalization" do
+      expect(page).not_to match_table(:users).with_rows(
+        {
+          "NAME" => "John Doe",
+          "EMAIL" => "john@example.com",
+          "STATUS" => "Active"
+        }
+      )
+    end
+
+    it "matches exact headers with spaces" do
+      expect(page).to match_table(:users).with_rows(
+        {
+          "Name" => "John Doe",
+          "Email" => "john@example.com",
+          "Status" => "Active"
+        }
+      )
+    end
+  end
+
+  context "with partial header matching (old behavior)" do
+    let(:html) do
+      <<-HTML
+        <table id="products">
+          <thead>
+            <tr>
+              <th>Product Name</th>
+              <th>Price</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>Widget</td>
+              <td>$10.00</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "does not match partial headers anymore" do
+      expect(page).not_to match_table(:products).with_rows(
+        {
+          "Product" => "Widget",
+          "Price" => "$10.00"
+        }
+      )
+    end
+
+    it "requires exact header match" do
+      expect(page).to match_table(:products).with_rows(
+        {
+          "Product Name" => "Widget",
+          "Price" => "$10.00"
+        }
+      )
+    end
+  end
+
+  context "with multiple rows and exact order" do
+    let(:html) do
+      <<-HTML
+        <table id="orders">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Customer</th>
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>001</td>
+              <td>Alice</td>
+              <td>$50.00</td>
+            </tr>
+            <tr data-table-target="row">
+              <td>002</td>
+              <td>Bob</td>
+              <td>$75.00</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "matches with exact headers in exact order" do
+      expect(page).to match_table(:orders).with_exact_rows(
+        {"ID" => "001", "Customer" => "Alice", "Total" => "$50.00"},
+        {"ID" => "002", "Customer" => "Bob", "Total" => "$75.00"}
+      )
+    end
+
+    it "fails with mismatched header case" do
+      expect(page).not_to match_table(:orders).with_exact_rows(
+        {"id" => "001", "customer" => "Alice", "total" => "$50.00"}
+      )
+    end
+  end
+end

--- a/spec/match_table_spec.rb
+++ b/spec/match_table_spec.rb
@@ -160,4 +160,182 @@ RSpec.describe "match_table matcher" do
       )
     end
   end
+
+  context "with sortable headers (arrow icons)" do
+    let(:html) do
+      <<-HTML
+        <table id="sortable">
+          <thead>
+            <tr>
+              <th>Name arrow_drop_down</th>
+              <th>Age   arrow_drop_up  </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>Charlie</td>
+              <td>30</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "normalizes headers by removing arrow icons and extra spaces" do
+      expect(page).to match_table(:sortable).with_rows(
+        {"Name" => "Charlie", "Age" => "30"}
+      )
+    end
+  end
+
+  context "with data-role attribute in headers" do
+    let(:html) do
+      <<-HTML
+        <table id="special">
+          <thead>
+            <tr>
+              <th><span data-role="header-text">Item</span></th>
+              <th>Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>Apple</td>
+              <td>5</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "extracts header text from data-role elements when th is empty" do
+      expect(page).to match_table(:special).with_rows(
+        {"Item" => "Apple", "Count" => "5"}
+      )
+    end
+  end
+
+  context "with accordion content rows" do
+    let(:html) do
+      <<-HTML
+        <table id="expandable">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>David</td>
+              <td>View</td>
+            </tr>
+            <tr data-accordion-content>
+              <td colspan="2">
+                <div>Expanded content here</div>
+              </td>
+            </tr>
+            <tr data-table-target="row">
+              <td>Eve</td>
+              <td>Edit</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "excludes rows inside accordion content" do
+      expect(page).to match_table(:expandable).with_exact_rows(
+        {"Name" => "David", "Action" => "View"},
+        {"Name" => "Eve", "Action" => "Edit"}
+      )
+    end
+  end
+
+  context "with tbody.contents class" do
+    let(:html) do
+      <<-HTML
+        <table id="filtered">
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody class="contents">
+            <tr data-table-target="row">
+              <td>Should be ignored</td>
+              <td>Contents class</td>
+            </tr>
+          </tbody>
+          <tbody>
+            <tr data-table-target="row">
+              <td>Visible</td>
+              <td>Normal tbody</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "only matches rows in tbody without 'contents' class" do
+      expect(page).to match_table(:filtered).with_exact_rows(
+        {"Type" => "Visible", "Value" => "Normal tbody"}
+      )
+    end
+  end
+
+  context "with string table identifier" do
+    let(:html) do
+      <<-HTML
+        <table>
+          <caption>My Table</caption>
+          <thead>
+            <tr>
+              <th>Column</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-table-target="row">
+              <td>Data</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "finds table by caption text (string identifier)" do
+      expect(page).to match_table("My Table").with_rows(
+        {"Column" => "Data"}
+      )
+    end
+  end
+
+  context "with rows that lack data-table-target attribute" do
+    let(:html) do
+      <<-HTML
+        <table id="targettest">
+          <thead>
+            <tr>
+              <th>Field</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Should not match</td>
+            </tr>
+            <tr data-table-target="row">
+              <td>Should match</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+    end
+
+    it "only matches rows with data-table-target='row' attribute" do
+      expect(page).to match_table(:targettest).with_exact_rows(
+        {"Field" => "Should match"}
+      )
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "capybara/rspec"
+require "capybara/dsl"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.disable_monkey_patching!
+  config.warnings = true
+  config.order = :random
+  Kernel.srand config.seed
+end
+
+Capybara.default_driver = :rack_test


### PR DESCRIPTION
This fixes an issue where if you have 2 headers that start with the same name, they are matched incorrectly.

Example: `Rate Type` and `Rate`

Failed CI build https://github.com/detaso/kairos/actions/runs/20854048848/job/59916924856?pr=2727